### PR TITLE
Check if curtrack is a string

### DIFF
--- a/helm-emms.el
+++ b/helm-emms.el
@@ -245,6 +245,7 @@ Returns nil when no music files are found."
            for curtrack = (emms-playlist-current-selected-track)
            for playing = (or (assoc-default 'info-title curtrack)
                              (and helm-emms-use-track-description-function
+                                  (stringp curtrack)
                                   (funcall emms-track-description-function curtrack)))
            if (member (cdr i) helm-emms-current-playlist)
            collect (cons (pcase (car i)


### PR DESCRIPTION
This prevents the modifier from failing when helm-emms-use-track-description-function is set to t.