### PR TITLE
Always add files as files, not as playlists.

### DIFF
--- a/helm-emms.el
+++ b/helm-emms.el
@@ -42,8 +42,8 @@
 (declare-function emms-playlist-current-clear "ext:emms")
 (declare-function emms-play-directory "ext:emms-source-file")
 (declare-function emms-play-file "ext:emms-source-file")
-(declare-function emms-add-playlist-file "ext:emms-source-playlist")
 (declare-function emms-add-directory "ext:emms-source-file")
+(declare-function emms-add-file "ext:emms-source-file")
 (defvar emms-player-playing-p)
 (defvar emms-browser-default-covers)
 (defvar emms-source-file-default-directory)
@@ -205,7 +205,7 @@ If a prefix arg is provided clear previous playlist."
     (when (or helm-current-prefix-arg current-prefix-arg)
       (emms-stop)
       (emms-playlist-current-clear))
-    (dolist (f files) (emms-add-playlist-file f))
+    (dolist (f files) (emms-add-file f))
     (unless emms-player-playing-p
       (helm-emms-play-current-playlist))))
 
@@ -331,7 +331,7 @@ Returns nil when no music files are found."
                     (when emms-player-playing-p
                       (emms-stop))
                     (emms-start))
-                (emms-add-playlist-file candidate)))))
+                (emms-add-file candidate)))))
       (emms-play-file candidate))
     (helm-force-update nil recenter)))
 


### PR DESCRIPTION
Performing the default action on a candidate from the "Music Directories" source adds files to the playlist as tracks with type `playlist` because `helm-emms-add-files-to-playlist` uses `emms-add-file-playlist`.

In my case, I have no player configured for playlists, so this action causes an error: `(error "Don’t know how to play track: (*track* (type . playlist) ...`.

Note that `emms-track` caches information including the track type, which can exacerbate the problem by continuing to use the wrong type even if the track is later added with the correct type specified.  This caching can also mask the problem if the track is added with the correct type before helm-emms adds it with the wrong type.

I see no reason to assume the files in a directory are playlists, so this pull request replaces use of `emms-add-file-playlist` with `emms-add-file`.

For completeness, this pull request also makes the same change to `helm-emms-files-persistent-action`, although it should not matter there due to the aforementioned caching.