### PR TITLE
Accommodate custom emms-browser-covers settings

### DIFF
--- a/helm-emms.el
+++ b/helm-emms.el
@@ -233,7 +233,7 @@ Returns nil when no music files are found."
 (defun helm-emms-dired-transformer (candidates _source)
   (cl-loop with files
            for d in candidates
-           for cover = (pcase (expand-file-name "cover_small.jpg" d)
+           for cover = (pcase (emms-browser-get-cover-from-path d 'small)
                          ((and c (pred file-exists-p)) c)
                          (_ (car emms-browser-default-covers)))
            for inplaylist = (member d helm-emms--directories-added-to-playlist)


### PR DESCRIPTION
With the previous code, users who changed `emms-browser-covers` to something else, like `'("artwork_small" ...)` would not work.  We should not hard code cover names.

Besides, the new code can leverage the dynamic thumbnail cache.  I'll push an optimized thumbnail function soon so that it can be usable in Helm-EMMS as benchmarked in #12.