### PR TITLE
Highlight currently played file when using custom track descriptions

### DIFF
--- a/helm-emms.el
+++ b/helm-emms.el
@@ -284,10 +284,9 @@ Returns nil when no music files are found."
 (defun helm-emms-files-modifier (candidates _source)
   (cl-loop for i in candidates
            for curtrack = (emms-playlist-current-selected-track)
-           for playing = (or (assoc-default 'info-title curtrack)
-                             (and helm-emms-use-track-description-function
-                                  (stringp curtrack)
-                                  (funcall emms-track-description-function curtrack)))
+           for playing = (or (and helm-emms-use-track-description-function
+                                  (funcall emms-track-description-function curtrack))
+                             (assoc-default 'info-title curtrack))
            if (member (cdr i) helm-emms-current-playlist)
            collect (cons (pcase (car i)
                            ((and str


### PR DESCRIPTION
Hey,

I noticed that when using a custom track description function, the currently played song is not highlighted in `helm-emms` using `emms-browser-track-face`.  If I understand this correctly, this it because `helm-emms-files-modifier` consideres the info-title property of the track first, and if that is not present also requires `curtrack` to be a string, which is never that case.  Reversing the test and removing the `stringp` test seems to fix the issue.

Commit description:
> When `helm-emms-use-track-description-function` is non-nil, candiates for
> `helm-source-emms-files` have a car formatted by
> `emms-track-description-function`.  To properly highlight the currently played
> track in this case, `helm-emms-files-modifier` should honor the custom track
> formatting first, such that the following `string-match-p` can succeed even if
> the currently played track has an info-title.  This can be achieved by switching
> the order of tests when defining the `playing` variable in
> `helm-emms-files-modifier`.  Moreover, `emms-playlist-current-selected-track`
> returns a track object, so the `stringp` test can never succed and is thus
> removed.

Best,

  Daniel