### PR TITLE
Add commentary section for helm-emms

### DIFF
--- a/helm-emms.el
+++ b/helm-emms.el
@@ -21,6 +21,14 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+
+;; This package provides a basic helm interface to emms, the Emacs Multimedia
+;; System.  This interface is accessible via the interactive `helm-emms' command
+;; and provides direct access to music directories, individual music files, and
+;; EMMS streams.  See the `helm-emms' customization group for available
+;; customizations, or simply call `helm-emms' to get started.
+
 ;;; Code:
 
 (require 'cl-lib)


### PR DESCRIPTION
This is displayed by `describe-package` and thus also indirectly in
`list-packages`.  Having a commentary thus should help users to understand what
this package is about.

Please feel free to change the description if you find anything missing.

Thanks,

  Daniel